### PR TITLE
Fix: Block-level lineage tracking in SDK seal

### DIFF
--- a/aadhaara/src/base/address.rs
+++ b/aadhaara/src/base/address.rs
@@ -106,6 +106,11 @@ impl BlockId {
         BlockId(Address(cid))
     }
 
+    /// Returns a null BlockId (all zeros).
+    pub fn null() -> Self {
+        Self::from_sha256(&[0u8; 32])
+    }
+
     /// Returns the raw binary representation of the identifier.
     pub fn to_bytes(&self) -> Vec<u8> {
         self.0.to_bytes()

--- a/aadhaara/src/graph/block.rs
+++ b/aadhaara/src/graph/block.rs
@@ -260,7 +260,7 @@ impl Block {
         parents: &[BlockId],
     ) -> Vec<u8> {
         let mut hasher = Sha256::new();
-        hasher.update(b"AKSHARA_V1_AD");
+        hasher.update(b"AKSHARA_V1_BLOCK_AD");
         hasher.update(graph_id.as_bytes());
         hasher.update(author.as_bytes());
         hasher.update(block_type.as_str().as_bytes());

--- a/aadhaara/src/graph/manifest.rs
+++ b/aadhaara/src/graph/manifest.rs
@@ -13,7 +13,7 @@ pub struct ManifestHeader {
     pub(crate) content_root: BlockId,
     pub(crate) parents: Vec<ManifestId>,
     pub(crate) identity_anchor: ManifestId,
-    pub(crate) signer_path: String,
+    pub(crate) signer_path_hash: [u8; 32],
     pub(crate) created_at: i64,
 }
 
@@ -41,12 +41,17 @@ impl Manifest {
         // determinism across different devices (Rebirth invariant).
         let created_at = 0i64;
 
+        // PATH OBFUSCATION: Hash the signer path to prevent Relay-side analysis
+        let mut path_hasher = Sha256::new();
+        path_hasher.update(signer.derivation_path().as_bytes());
+        let signer_path_hash: [u8; 32] = path_hasher.finalize().into();
+
         let header = ManifestHeader {
             graph_id,
             content_root,
             parents,
             identity_anchor,
-            signer_path: signer.derivation_path().to_string(),
+            signer_path_hash,
             created_at,
         };
 
@@ -96,8 +101,8 @@ impl Manifest {
         self.header.created_at
     }
 
-    pub fn signer_path(&self) -> &str {
-        &self.header.signer_path
+    pub fn signer_path_hash(&self) -> &[u8; 32] {
+        &self.header.signer_path_hash
     }
 
     /// Public-Crate API: Used by sibling crates for wire mapping.
@@ -144,12 +149,7 @@ impl Manifest {
         }
         hasher.update(header.identity_anchor.as_ref());
         hasher.update(author.as_bytes());
-
-        // PATH OBFUSCATION: Hash the signer path to prevent Relay-side analysis
-        let mut path_hasher = Sha256::new();
-        path_hasher.update(header.signer_path.as_bytes());
-        hasher.update(path_hasher.finalize());
-
+        hasher.update(header.signer_path_hash);
         hasher.update(header.created_at.to_le_bytes());
 
         ManifestId::from_sha256(&hasher.finalize())

--- a/aadhaara/src/graph/test_manifest.rs
+++ b/aadhaara/src/graph/test_manifest.rs
@@ -139,7 +139,7 @@ fn manifest_restores_from_raw_parts() {
         content_root: original.content_root(),
         parents: original.parents().to_vec(),
         identity_anchor: original.identity_anchor(),
-        signer_path: original.signer_path().to_string(),
+        signer_path_hash: *original.signer_path_hash(),
         created_at: original.created_at(),
     };
 

--- a/aadhaara/src/identity/derivation.rs
+++ b/aadhaara/src/identity/derivation.rs
@@ -3,6 +3,8 @@ use ed25519_dalek::SigningKey;
 use hmac::{Hmac, Mac};
 use sha2::Sha512;
 
+use zeroize::{Zeroize, Zeroizing};
+
 /// Implements SLIP-0010 Hardened Derivation for Ed25519.
 ///
 /// This is the mathematical engine of the Akshara Identity tree. It follows
@@ -12,12 +14,13 @@ pub fn derive_slip0010_key(seed: &[u8; 64], path: &str) -> Result<SigningKey, Ak
     let mut hmac = Hmac::<Sha512>::new_from_slice(b"ed25519 seed")
         .map_err(|e| AksharaError::InternalError(e.to_string()))?;
     hmac.update(seed);
-    let output = hmac.finalize().into_bytes();
+    let mut output = hmac.finalize().into_bytes();
 
-    let mut current_key = [0u8; 32];
-    let mut current_chain = [0u8; 32];
+    let mut current_key = Zeroizing::new([0u8; 32]);
+    let mut current_chain = Zeroizing::new([0u8; 32]);
     current_key.copy_from_slice(&output[0..32]);
     current_chain.copy_from_slice(&output[32..64]);
+    output.zeroize();
 
     let segments = path.split('/').collect::<Vec<_>>();
     if segments[0] != "m" {
@@ -41,18 +44,21 @@ pub fn derive_slip0010_key(seed: &[u8; 64], path: &str) -> Result<SigningKey, Ak
             )));
         };
 
-        let mut hmac = Hmac::<Sha512>::new_from_slice(&current_chain)
+        let mut hmac = Hmac::<Sha512>::new_from_slice(current_chain.as_slice())
             .map_err(|e| AksharaError::InternalError(e.to_string()))?;
 
         // SLIP-0010 Hardened Step: [0x00] || [ParentKey] || [Index]
         hmac.update(&[0x00]);
-        hmac.update(&current_key);
+        hmac.update(current_key.as_slice());
         hmac.update(&index.to_be_bytes());
-        let output = hmac.finalize().into_bytes();
+        let mut output = hmac.finalize().into_bytes();
 
         current_key.copy_from_slice(&output[0..32]);
         current_chain.copy_from_slice(&output[32..64]);
+        output.zeroize();
     }
 
-    Ok(SigningKey::from_bytes(&current_key))
+    Ok(SigningKey::from_bytes(
+        current_key.as_slice().try_into().unwrap(),
+    ))
 }

--- a/aadhaara/src/identity/mnemonic.rs
+++ b/aadhaara/src/identity/mnemonic.rs
@@ -22,7 +22,7 @@ pub fn mnemonic_to_seed(
     phrase: &str,
     passphrase: &str,
 ) -> Result<Zeroizing<[u8; 64]>, AksharaError> {
-    let normalized = phrase.trim().to_lowercase();
+    let normalized = Zeroizing::new(phrase.trim().to_lowercase());
     let words: Vec<&str> = normalized.split_whitespace().collect();
     if words.len() != 24 {
         return Err(AksharaError::Identity(IdentityError::MnemonicInvalid(

--- a/aadhaara/src/identity/types.rs
+++ b/aadhaara/src/identity/types.rs
@@ -43,9 +43,11 @@ impl Identity {
 }
 
 /// `SecretIdentity` is a functional credential derived for a specific path.
+#[derive(zeroize::Zeroize, zeroize::ZeroizeOnDrop)]
 pub struct SecretIdentity {
     pub(crate) signing_key: SigningSecretKey,
     pub(crate) encryption_key: EncryptionSecretKey,
+    #[zeroize(skip)]
     pub(crate) public: Identity,
     pub(crate) derivation_path: String,
 }
@@ -250,11 +252,11 @@ impl SecretIdentity {
     }
 
     /// Serialize the identity to bytes (64 bytes: 32-byte signing key + 32-byte encryption key).
-    pub fn to_bytes(&self) -> Vec<u8> {
+    pub fn to_bytes(&self) -> Zeroizing<Vec<u8>> {
         let mut bytes = Vec::with_capacity(64);
         bytes.extend_from_slice(self.signing_key.as_bytes());
         bytes.extend_from_slice(self.encryption_key.as_bytes());
-        bytes
+        Zeroizing::new(bytes)
     }
 
     /// Deserialize an identity from bytes (64 bytes).

--- a/aadhaara/src/traversal/auditor.rs
+++ b/aadhaara/src/traversal/auditor.rs
@@ -4,6 +4,7 @@ use crate::base::error::AksharaError;
 use crate::graph::{Block, Manifest};
 use crate::identity::IdentityGraph;
 use crate::state::store::GraphStore;
+use sha2::Digest;
 use tracing::{Level, debug, span};
 
 /// `Auditor` is the platform's Trust Gatekeeper.
@@ -45,15 +46,18 @@ impl<'a, S: GraphStore + ?Sized> Auditor<'a, S> {
 
         // Tier 2: Path-Aware Purpose Enforcement
         // Genesis manifests (administrative) MUST be signed by a Legislator (m/0')
-        if manifest.identity_anchor() == ManifestId::null()
-            && !crate::identity::paths::is_legislator_path(manifest.signer_path())
-        {
-            return Err(crate::base::error::AksharaError::Integrity(
-                crate::base::error::IntegrityError::UnauthorizedSigner(format!(
-                    "Administrative action requires Legislator branch, but signed by {}",
-                    manifest.signer_path()
-                )),
-            ));
+        if manifest.identity_anchor() == ManifestId::null() {
+            let mut hasher = sha2::Sha256::new();
+            hasher.update(b"m/44'/999'/0'/0'/0'"); // Standard Akshara Legislator path
+            let legislator_hash: [u8; 32] = hasher.finalize().into();
+
+            if manifest.signer_path_hash() != &legislator_hash {
+                return Err(crate::base::error::AksharaError::Integrity(
+                    crate::base::error::IntegrityError::UnauthorizedSigner(
+                        "Administrative action requires Legislator branch (m/0') hash, but found mismatch".to_string()
+                    ),
+                ));
+            }
         }
 
         // Tier 3: Social Authority (Causality)

--- a/aadhaara/src/traversal/test_traversal.rs
+++ b/aadhaara/src/traversal/test_traversal.rs
@@ -7,6 +7,7 @@ use crate::{
         create_chain, create_dummy_root, create_identity, create_valid_anchor, walker::GraphWalker,
     },
 };
+use sha2::Digest;
 
 #[tokio::test]
 async fn walker_with_corrupted_index_block() {
@@ -147,12 +148,17 @@ async fn walker_handles_manifest_cycles_gracefully() {
 
     // To test cycles in ancestors, we must use from_raw_parts to force a self-pointer
     let cycle_id = ManifestId::from_sha256(&[0x99; 32]);
+
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(identity.derivation_path().as_bytes());
+    let signer_path_hash: [u8; 32] = hasher.finalize().into();
+
     let header = crate::graph::manifest::ManifestHeader {
         graph_id,
         content_root: root,
         parents: vec![cycle_id], // Point to self!
         identity_anchor: anchor,
-        signer_path: identity.derivation_path().to_string(),
+        signer_path_hash,
         created_at: 12345,
     };
 

--- a/akshara/src/client.rs
+++ b/akshara/src/client.rs
@@ -60,13 +60,9 @@ impl Client {
         // Get graph key from vault
         let graph_key = self.vault.derive_graph_key(&graph_id).await?;
 
-        // Get current identity anchor
-        let identity_anchor = self.vault.latest_identity_anchor();
-
         Ok(Graph::new(
             graph_id,
             graph_key,
-            identity_anchor,
             self.vault.clone(),
             self.store.clone(),
             self.staging.clone(),
@@ -87,13 +83,9 @@ impl Client {
         // Get graph key from vault
         let graph_key = self.vault.derive_graph_key(&graph_id).await?;
 
-        // Get current identity anchor
-        let identity_anchor = self.vault.latest_identity_anchor();
-
         Ok(Graph::new(
             graph_id,
             graph_key,
-            identity_anchor,
             self.vault.clone(),
             self.store.clone(),
             self.staging.clone(),

--- a/akshara/src/graph.rs
+++ b/akshara/src/graph.rs
@@ -63,6 +63,16 @@ impl Graph {
         self.graph_id
     }
 
+    /// Get the graph key.
+    pub fn key(&self) -> &GraphKey {
+        &self.graph_key
+    }
+
+    /// Get the storage backend.
+    pub fn store(&self) -> &InMemoryStore {
+        &self.store
+    }
+
     // ========================================================================
     // Staged Writes
     // ========================================================================
@@ -181,6 +191,52 @@ impl Graph {
         Ok(content)
     }
 
+    /// Returns the BlockId (CID) for the specified path.
+    pub async fn get_id(&self, path: &str) -> Result<akshara_aadhaara::BlockId> {
+        // Get current heads from store
+        let heads = self
+            .store
+            .get_heads(&self.graph_id)
+            .await
+            .map_err(|e| Error::Internal(format!("Failed to get heads: {}", e)))?;
+
+        if heads.is_empty() {
+            return Err(Error::PathNotFound(format!(
+                "No data sealed yet for path: {}",
+                path
+            )));
+        }
+
+        let manifest_id = heads[0];
+        let manifest = self
+            .store
+            .get_manifest(&manifest_id)
+            .await
+            .map_err(|e| Error::Internal(format!("Failed to get manifest: {}", e)))?
+            .ok_or_else(|| Error::Internal("Manifest not found".to_string()))?;
+
+        let identity = self.vault.get_identity().await?;
+        let walker = akshara_aadhaara::GraphWalker::new(
+            &self.store,
+            identity.public().signing_key().clone(),
+        );
+
+        let address = walker
+            .resolve_path(
+                &self.graph_id,
+                manifest.content_root(),
+                path,
+                &self.graph_key,
+            )
+            .await
+            .map_err(|e| {
+                Error::PathNotFound(format!("Path resolution failed for '{}': {}", path, e))
+            })?;
+
+        akshara_aadhaara::BlockId::try_from(address)
+            .map_err(|e| Error::Internal(format!("Address conversion failed: {}", e)))
+    }
+
     /// Check if content exists at the specified path.
     pub async fn exists(&self, path: &str) -> Result<bool> {
         match self.get(path).await {
@@ -290,18 +346,17 @@ impl Graph {
 
             // Check if this is a data block or another index by trying to convert to BlockId
             // and checking the block type
-            if let Ok(block_id) = akshara_aadhaara::BlockId::try_from(address) {
-                // Get the block to check its type
-                if let Ok(Some(child_block)) = self.store.get_block(&block_id).await {
-                    match child_block.block_type() {
-                        akshara_aadhaara::BlockType::AksharaIndexV1 => {
-                            // Index block - recurse with Box::pin to avoid infinite size
-                            Box::pin(self.collect_paths(block_id, &full_path, paths)).await?;
-                        }
-                        _ => {
-                            // Data block - add to paths
-                            paths.push(full_path);
-                        }
+            if let Ok(block_id) = akshara_aadhaara::BlockId::try_from(address)
+                && let Ok(Some(child_block)) = self.store.get_block(&block_id).await
+            {
+                match child_block.block_type() {
+                    akshara_aadhaara::BlockType::AksharaIndexV1 => {
+                        // Index block - recurse with Box::pin to avoid infinite size
+                        Box::pin(self.collect_paths(block_id, &full_path, paths)).await?;
+                    }
+                    _ => {
+                        // Data block - add to paths
+                        paths.push(full_path);
                     }
                 }
             }
@@ -344,7 +399,17 @@ impl Graph {
             match op {
                 StagedOperation::Insert { path, data, .. }
                 | StagedOperation::Update { path, data, .. } => {
-                    current_state.insert(path.clone(), data.clone());
+                    // When updating, we replace the entry in the map.
+                    // If a previous entry existed, its ID becomes the parent of the new block.
+                    // We generate a dummy ID for fresh inserts to keep the logic uniform.
+                    let prev_id_opt = current_state.get(path).map(|(_, id)| *id);
+                    current_state.insert(
+                        path.clone(),
+                        (
+                            data.clone(),
+                            prev_id_opt.unwrap_or(akshara_aadhaara::BlockId::null()),
+                        ),
+                    );
                 }
                 StagedOperation::Delete { path, .. } => {
                     current_state.remove(path);
@@ -363,18 +428,25 @@ impl Graph {
         let mut blocks_created = 0;
         let mut bytes_sealed = 0;
 
-        for (path, data) in current_state {
+        for (path, (data, prev_id)) in current_state {
             // Check if we need to chunk
             if data.len() > self.tuning.max_block_size {
                 // Chunk large payload - TODO: implement
                 return Err(Error::ChunkingFailed("not implemented yet".to_string()));
             } else {
+                // LINEAGE RITUAL: If this is an update, set the previous block as parent
+                let parents = if prev_id != akshara_aadhaara::BlockId::null() {
+                    vec![prev_id]
+                } else {
+                    vec![]
+                };
+
                 // Single block
                 let block = Block::new(
                     self.graph_id,
                     data.clone(),
                     BlockType::AksharaDataV1,
-                    vec![],
+                    parents,
                     &self.graph_key,
                     &identity,
                 )?;
@@ -437,7 +509,9 @@ impl Graph {
     ///
     /// TODO: This is currently O(N) where N is the number of blocks in the graph.
     /// For v0.2, we should implement incremental state loading or an LRU cache.
-    async fn load_current_state(&self) -> Result<std::collections::BTreeMap<String, Vec<u8>>> {
+    async fn load_current_state(
+        &self,
+    ) -> Result<std::collections::BTreeMap<String, (Vec<u8>, akshara_aadhaara::BlockId)>> {
         // Get current heads
         let heads = self
             .store
@@ -461,7 +535,7 @@ impl Graph {
 
         // Load all paths from the index
         let mut state = std::collections::BTreeMap::new();
-        self.load_state_from_index(manifest.content_root(), &mut state)
+        self.load_state_from_index(manifest.content_root(), "", &mut state)
             .await?;
 
         Ok(state)
@@ -471,7 +545,8 @@ impl Graph {
     async fn load_state_from_index(
         &self,
         index_id: akshara_aadhaara::BlockId,
-        state: &mut std::collections::BTreeMap<String, Vec<u8>>,
+        prefix: &str,
+        state: &mut std::collections::BTreeMap<String, (Vec<u8>, akshara_aadhaara::BlockId)>,
     ) -> Result<()> {
         // Get the index block
         let block = self
@@ -492,7 +567,11 @@ impl Graph {
                 .map_err(|e| Error::Internal(format!("Failed to parse index: {}", e)))?;
 
         for (key, address) in index_map {
-            let full_path = format!("/{}", key);
+            let full_path = if prefix.is_empty() {
+                format!("/{}", key)
+            } else {
+                format!("{}/{}", prefix, key)
+            };
 
             // Try to convert to BlockId and load the block
             if let Ok(block_id) = akshara_aadhaara::BlockId::try_from(address)
@@ -501,14 +580,14 @@ impl Graph {
                 match child_block.block_type() {
                     akshara_aadhaara::BlockType::AksharaIndexV1 => {
                         // Index block - recurse with Box::pin to avoid infinite size
-                        Box::pin(self.load_state_from_index(block_id, state)).await?;
+                        Box::pin(self.load_state_from_index(block_id, &full_path, state)).await?;
                     }
                     _ => {
-                        // Data block - decrypt and add to state
+                        // Data block - decrypt and add to state with its ID
                         let data = child_block
                             .decrypt(&self.graph_id, &self.graph_key)
                             .map_err(|e| Error::Internal(format!("Decryption failed: {}", e)))?;
-                        state.insert(full_path, data);
+                        state.insert(full_path, (data, block_id));
                     }
                 }
             }
@@ -567,4 +646,153 @@ fn current_timestamp() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ClientConfig;
+    use crate::vault::create_vault;
+    use akshara_aadhaara::SecretIdentity;
+
+    async fn create_test_graph() -> Graph {
+        let mnemonic = SecretIdentity::generate_mnemonic().unwrap();
+        let config = ClientConfig::new().with_ephemeral_vault();
+        let vault = create_vault(config.vault).unwrap();
+        vault.initialize(Some(mnemonic)).await.unwrap();
+
+        let identity = vault.get_identity().await.unwrap();
+        let store = InMemoryStore::new();
+        let graph_id = GraphId::new();
+        let graph_key = identity.derive_graph_key(&graph_id).unwrap();
+
+        Graph::new(
+            graph_id,
+            graph_key,
+            vault,
+            store,
+            Arc::new(Mutex::new(Box::new(
+                crate::staging::InMemoryStagingStore::new(),
+            ))),
+            TuningConfig::default(),
+        )
+    }
+
+    #[tokio::test]
+    async fn test_block_lineage_is_preserved_during_seal() {
+        let graph = create_test_graph().await;
+        let path = "/test/lineage";
+
+        // 1. Initial write
+        graph.insert(path, b"v1").await.unwrap();
+        graph.seal().await.unwrap();
+        let id1 = graph.get_id(path).await.unwrap();
+
+        // 2. Update the same path
+        graph.update(path, b"v2").await.unwrap();
+        graph.seal().await.unwrap();
+        let id2 = graph.get_id(path).await.unwrap();
+
+        // 3. Verify that the new block points to the old block as its parent
+        let block2 = graph
+            .store
+            .get_block(&id2)
+            .await
+            .unwrap()
+            .expect("Block 2 should exist");
+
+        assert_ne!(id1, id2, "Block IDs must change when content changes");
+        assert!(
+            block2.parents().contains(&id1),
+            "Updated block should list previous version {} as parent. Found: {:?}",
+            id1,
+            block2.parents()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_multi_generation_lineage() {
+        let graph = create_test_graph().await;
+        let path = "/test/generations";
+
+        // G1
+        graph.insert(path, b"gen1").await.unwrap();
+        graph.seal().await.unwrap();
+        let id1 = graph.get_id(path).await.unwrap();
+
+        // G2
+        graph.update(path, b"gen2").await.unwrap();
+        graph.seal().await.unwrap();
+        let id2 = graph.get_id(path).await.unwrap();
+
+        // G3
+        graph.update(path, b"gen3").await.unwrap();
+        graph.seal().await.unwrap();
+        let id3 = graph.get_id(path).await.unwrap();
+
+        // Verify G3 points to G2
+        let b3 = graph.store.get_block(&id3).await.unwrap().unwrap();
+        assert!(b3.parents().contains(&id2));
+
+        // Verify G2 points to G1
+        let b2 = graph.store.get_block(&id2).await.unwrap().unwrap();
+        assert!(b2.parents().contains(&id1));
+    }
+
+    #[tokio::test]
+    async fn test_lineage_after_deletion_and_reinsertion() {
+        let graph = create_test_graph().await;
+        let path = "/test/reset";
+
+        // 1. Insert and Seal
+        graph.insert(path, b"first").await.unwrap();
+        graph.seal().await.unwrap();
+        let id1 = graph.get_id(path).await.unwrap();
+
+        // 2. Delete and Seal
+        graph.delete(path).await.unwrap();
+        graph.seal().await.unwrap();
+        assert!(
+            graph.get_id(path).await.is_err(),
+            "Path should be gone after delete"
+        );
+
+        // 3. Re-insert and Seal
+        graph.insert(path, b"second").await.unwrap();
+        graph.seal().await.unwrap();
+        let id2 = graph.get_id(path).await.unwrap();
+
+        // 4. Verify that re-insertion starts a NEW lineage (no parents)
+        let b2 = graph.store.get_block(&id2).await.unwrap().unwrap();
+        assert!(
+            b2.parents().is_empty(),
+            "Re-insertion after deletion should have no parents"
+        );
+        assert_ne!(id1, id2);
+    }
+
+    #[tokio::test]
+    async fn test_coalesced_update_lineage() {
+        let graph = create_test_graph().await;
+        let path = "/test/coalesce";
+
+        // 1. Initial stable state
+        graph.insert(path, b"original").await.unwrap();
+        graph.seal().await.unwrap();
+        let id_orig = graph.get_id(path).await.unwrap();
+
+        // 2. Stage multiple updates BEFORE sealing
+        graph.update(path, b"temp1").await.unwrap();
+        graph.update(path, b"temp2").await.unwrap();
+        graph.update(path, b"final").await.unwrap();
+
+        // 3. Seal (should coalesce to just "final")
+        graph.seal().await.unwrap();
+        let id_final = graph.get_id(path).await.unwrap();
+
+        // 4. Verify that "final" points to "original", skipping the temp states
+        let b_final = graph.store.get_block(&id_final).await.unwrap().unwrap();
+        assert!(b_final.parents().contains(&id_orig));
+        assert_eq!(b_final.parents().len(), 1);
+    }
 }

--- a/akshara/src/graph.rs
+++ b/akshara/src/graph.rs
@@ -23,7 +23,6 @@ use crate::vault::Vault;
 pub struct Graph {
     graph_id: GraphId,
     graph_key: GraphKey,
-    identity_anchor: ManifestId,
     vault: Arc<dyn Vault>,
     store: InMemoryStore,
     staging: Arc<Mutex<Box<dyn StagingStore>>>,
@@ -37,7 +36,6 @@ impl Graph {
     ///
     /// * `graph_id` - The graph identifier
     /// * `graph_key` - The symmetric encryption key for this graph
-    /// * `identity_anchor` - The latest known identity state CID
     /// * `vault` - Reference to the vault (holds secret keys securely)
     /// * `store` - Storage backend for blocks and manifests
     /// * `staging` - Staging store for buffering operations
@@ -45,7 +43,6 @@ impl Graph {
     pub fn new(
         graph_id: GraphId,
         graph_key: GraphKey,
-        identity_anchor: ManifestId,
         vault: Arc<dyn Vault>,
         store: InMemoryStore,
         staging: Arc<Mutex<Box<dyn StagingStore>>>,
@@ -54,7 +51,6 @@ impl Graph {
         Self {
             graph_id,
             graph_key,
-            identity_anchor,
             vault,
             store,
             staging,
@@ -403,12 +399,16 @@ impl Graph {
             .await
             .unwrap_or_default();
 
+        // AKSHARA SECURITY MANDATE: Always anchor to the LATEST known identity state.
+        // This ensures the manifest respects any revocations in the current frontier.
+        let identity_anchor = self.vault.latest_identity_anchor();
+
         // Create manifest
         let manifest = Manifest::new(
             self.graph_id,
             root_index_id,
             parents,
-            self.identity_anchor,
+            identity_anchor,
             &identity,
         );
 

--- a/akshara/src/vault.rs
+++ b/akshara/src/vault.rs
@@ -139,21 +139,22 @@ impl PlatformVault {
     }
 
     /// Load a specific branch from keychain.
-    fn load_branch(&self, index: u32) -> Result<Vec<u8>> {
+    fn load_branch(&self, index: u32) -> Result<Zeroizing<Vec<u8>>> {
         let key = Self::branch_key(index);
         let entry = keyring::Entry::new(&self.service, &key)
             .map_err(|e| VaultError::Keychain(format!("Keychain entry creation failed: {}", e)))?;
 
-        let hex_str = entry
-            .get_password()
-            .map_err(|e| VaultError::KeyNotFound(format!("Branch {} not found: {}", index, e)))?;
+        let hex_str =
+            Zeroizing::new(entry.get_password().map_err(|e| {
+                VaultError::KeyNotFound(format!("Branch {} not found: {}", index, e))
+            })?);
 
-        // Decode from hex
-        let bytes = hex::decode(&hex_str).map_err(|e| {
+        // Decode from hex into a zeroizing vector
+        let bytes = hex::decode(&*hex_str).map_err(|e| {
             VaultError::KeyNotFound(format!("Branch {} decode failed: {}", index, e))
         })?;
 
-        Ok(bytes)
+        Ok(Zeroizing::new(bytes))
     }
 
     /// Save a branch to keychain.
@@ -162,7 +163,7 @@ impl PlatformVault {
         let entry = keyring::Entry::new(&self.service, &key)
             .map_err(|e| VaultError::Keychain(format!("Keychain entry creation failed: {}", e)))?;
 
-        let hex_str = hex::encode(bytes);
+        let hex_str = Zeroizing::new(hex::encode(bytes));
         entry
             .set_password(&hex_str)
             .map_err(|e| VaultError::Keychain(e.to_string()))?;

--- a/docs/akshara/README.md
+++ b/docs/akshara/README.md
@@ -51,9 +51,10 @@ The `akshara` crate is the **primary interface** for application developers buil
 |-----------|-------------|
 | **You Handle Plaintext, We Handle Vault** | Developers work with strings/bytes. Encryption, signing, key management are automatic. |
 | **Offline is Default** | All writes are local first. Sync is explicit, background, and resumable. |
-| **Paths, Not CIDs** | Humans think `/notes/meeting.md`. The API maps paths to CIDs internally. |
-| **Seal is Explicit** | Buffering is automatic, but committing to the DAG is a conscious choice. |
-| **Conflicts are Events** | Concurrent edits create branches. The app decides merge strategy. |
+| **Blocks as Atomic Units** | Content is stored in immutable **Blocks**. Paths serve as the coordinates for these blocks within the Merkle-Index. |
+| **Fractional Indexing** | The API uses fractional indexing to maintain ordered sequences of blocks without expensive re-indexing of the entire graph. |
+| **Seal is Explicit** | Buffering is automatic, but committing blocks to the DAG via a **Manifest** is a conscious choice. |
+| **Conflicts are Events** | Concurrent edits to the same path create branches. The app decides merge strategy. |
 
 ---
 

--- a/docs/specs/synchronization/reconciliation.md
+++ b/docs/specs/synchronization/reconciliation.md
@@ -96,9 +96,26 @@ Reconciliation is the process of identifying the difference between two separate
 | **Surplus** | `Surplus(A, B) = Known(B) - Known(A)` |
 | **Delta** | `Delta(Surplus) = Surplus ∪ { b ∈ Blocks | b referenced by m ∈ Surplus }` |
 
+## 4. Sync Modes
+
+Akshara supports two reconciliation modes to balance performance and completeness.
+
+### 4.1. Fast Sync (Shallow Reconciliation)
+*   **Purpose:** Rapid state availability for edge devices.
+*   **Logic:** The `Reconciler` recursively identifies missing `Manifests` and their immediate `content_root` blocks. It stops the recursive walk at the **Lowest Common Ancestor (LCA)** of the manifests.
+*   **Invariant:** Only the latest versions of resources (and any concurrent conflicts) are identified. Historical "atoms" (block parents) older than the LCA are ignored.
+
+### 4.2. Full Sync (Deep Reconciliation)
+*   **Purpose:** Archival durability and total history preservation (Relays).
+*   **Logic:** The `Reconciler` recursively identifies EVERY `Manifest` and EVERY `Block` parent in the surplus history.
+*   **Invariant:** Every atom of the graph is identified, ensuring the entire Resource DAG is preserved.
+
+### 4.3. Conflict Identification
+Regardless of the mode, the `Reconciler` MUST identify **concurrent heads** (forks). If multiple manifests share a common ancestor but have no common child, all divergent blocks for a given path MUST be included in the `Delta` to ensure the application layer can surface the conflict to the user.
+
 ---
 
-## 4. Reconciliation Algorithm
+## 5. Reconciliation Algorithm
 
 ### 4.1. Main Algorithm
 


### PR DESCRIPTION
This PR implements atom-level history preservation by ensuring that the SDK tracks the previous version of every resource and sets it as a parent during the sealing ritual. Ref Issue #9.